### PR TITLE
Extensions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -105,9 +105,23 @@ def update_model_parameters(state, initial=False):
         elif element == 'cpu_memory' and value is not None:
             value = f"{value}MiB"
 
+        if element in ['pre_layer']:
+            value = [value] if value > 0 else None
+
         setattr(shared.args, element, value)
 
-    shared.need_restart = True
+    found_positive = False
+    for i in gpu_memories:
+        if i > 0:
+            found_positive = True
+            break
+
+    if not (initial and vars(shared.args)['gpu_memory'] != vars(shared.args_defaults)['gpu_memory']):
+        if found_positive:
+            shared.args.gpu_memory = [f"{i}MiB" for i in gpu_memories]
+        else:
+            shared.args.gpu_memory = None
+            
 #Load Extensions    
 extensions_module.available_extensions = utils.get_available_extensions()
 if shared.args.extensions is not None and len(shared.args.extensions) > 0:

--- a/bot.py
+++ b/bot.py
@@ -107,7 +107,8 @@ def update_model_parameters(state, initial=False):
     shared.need_restart = True
 #Load Extensions    
 extensions_module.available_extensions = utils.get_available_extensions()
-extensions_module.load_extensions()
+if shared.args.extensions is not None and len(shared.args.extensions) > 0:
+    extensions_module.load_extensions()
 
 
 #Discord Bot


### PR DESCRIPTION
This commit carries over certain excerpts of code that makes arguments working on the Ooba Webui work with the bot, which also allows loading extensions. Not all extensions would be compatible with the bot at this point, if any. You'll have to install individual requirements for the extension you're trying to load.

Edit 1: So far my findings are "google_translate" extension just works™. "EdgeGPT" doesn't work, see the issue. STT won't work, but there are ways to make the bot listen for audio in a voice chat according to Google™. Maybe it's doable?

"silero_tts" works, but the generated sound file isn't send to discord api, and the extension returns a html tag, so bot replies `<audio src="file/extensions/silero_tts/outputs/Diffusion_1652324478.wav" controls autoplay></audio>`. 